### PR TITLE
Included @Valid, BindingResult in ProjectController

### DIFF
--- a/src/main/java/com/jira_app/ppmtool/web/ProjectController.java
+++ b/src/main/java/com/jira_app/ppmtool/web/ProjectController.java
@@ -2,10 +2,12 @@ package com.jira_app.ppmtool.web;
 
 import com.jira_app.ppmtool.domain.Project;
 import com.jira_app.ppmtool.services.ProjectService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,8 +24,10 @@ public class ProjectController {
     }
 
     @PostMapping("")
-    public ResponseEntity<Project> createNewProject(@RequestBody Project project){
-
+    public ResponseEntity<?> createNewProject(@Valid @RequestBody Project project, BindingResult result){
+        if(result.hasErrors()){
+            return new ResponseEntity<String>("Invalid Project Object",HttpStatus.BAD_REQUEST);
+        }
         projectService.saveOrUpdate(project);
         return new ResponseEntity<Project>(project, HttpStatus.CREATED);
     }


### PR DESCRIPTION
**Added @Valid in @PostMapping("") for Project Controller.** 
The @Valid annotation in Spring Boot is used to trigger validation on the objects passed as method parameters in controller methods, service methods, or even within entities. When applied, it ensures that the validation annotations (like @NotBlank, @Size, etc.) inside those objects are evaluated.

**Included BindingResult in @PostMapping("") for Project Controller**
The BindingResult interface in Spring is used to capture the result of validation and data binding. When you use @Valid or @Validated to validate objects in Spring, BindingResult can be used as a method parameter to handle the validation results. It provides detailed information about validation errors, allowing you to customize how errors are processed and returned.