### PR TITLE
Used HashMap to parse FieldErrors

### DIFF
--- a/src/main/java/com/jira_app/ppmtool/web/ProjectController.java
+++ b/src/main/java/com/jira_app/ppmtool/web/ProjectController.java
@@ -8,10 +8,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/project")
@@ -26,7 +31,12 @@ public class ProjectController {
     @PostMapping("")
     public ResponseEntity<?> createNewProject(@Valid @RequestBody Project project, BindingResult result){
         if(result.hasErrors()){
-            return new ResponseEntity<String>("Invalid Project Object",HttpStatus.BAD_REQUEST);
+            Map<String,String> errorMap = new HashMap<>();
+            for(FieldError error: result.getFieldErrors()){
+                errorMap.put(error.getField(),error.getDefaultMessage());
+            }
+
+            return new ResponseEntity<Map>(errorMap,HttpStatus.BAD_REQUEST);
         }
         projectService.saveOrUpdate(project);
         return new ResponseEntity<Project>(project, HttpStatus.CREATED);


### PR DESCRIPTION
Instead of directly returning a Response Entity with the result (from BindingResult), we return the specific field errors in the format of 

{ 
result.getFieldErrors().getField() : result.getFieldErrors().getDefaultMessage()
}

For this, we have used a HashMap and iterated through all the field errors from result.getFieldErrors()